### PR TITLE
ログイン済ヘッダーに出品するボタン設置、ユーザー詳細に自身のアイテムを表示

### DIFF
--- a/src/component/organisms/header/loggedInHeader.tsx
+++ b/src/component/organisms/header/loggedInHeader.tsx
@@ -28,6 +28,28 @@ export const LoggedInHeader = () => {
         <nav>
           <ul className="items-center gap-4 font-medium flex space-y-0 mr-auto ml-8">
             <li>
+              <Link
+                href="/item/new"
+                className="inline-flex items-center gap-1.5 rounded-md border border-primary-500 bg-primary-500 px-3 py-1.5 text-center text-sm font-medium text-white shadow-sm transition-all hover:border-primary-700 hover:bg-primary-700 focus:ring focus:ring-primary-200 disabled:cursor-not-allowed disabled:border-primary-300 disabled:bg-primary-300"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 4.5v15m7.5-7.5h-15"
+                  />
+                </svg>
+                出品する
+              </Link>
+            </li>
+            <li>
               <Link href="/message">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/pages/index.tsx
+++ b/src/pages/pages/index.tsx
@@ -7,51 +7,21 @@ const pages = () => {
     { path: "login/", description: "ログイン", status: "済" },
     { path: "register/", description: "新規会員登録", status: "済" },
     { path: "/", description: "サイトトップ", status: "済" },
-    {
-      path: "category/1",
-      description: "カテゴリーから探す（静的一覧）",
-      status: "済",
-    },
+
     {
       path: "search/",
       description: "様々な条件から探す（動的一覧）",
       status: "済",
     },
-    {
-      path: "keep/",
-      description: "気になる商品・ユーザーのストック",
-      status: "済",
-    },
-    {
-      path: "viewed/1",
-      description: "閲覧した商品・ユーザーのページ",
-      status: "済",
-    },
 
     { path: "item/1", description: "商品詳細", status: "済" },
     { path: "item/1/edit", description: "商品詳細-編集", status: "済" },
-    { path: "item/1/edit", description: "商品詳細-新規", status: "済" },
+    { path: "item/new", description: "商品詳細-新規", status: "済" },
 
     { path: "user/1", description: "ユーザー詳細", status: "済" },
-
     { path: "user/1/edit", description: "ユーザー詳細-編集", status: "済" },
-    {
-      path: "request/1",
-      description: "リクエスト詳細",
-      status: "-",
-    },
-    {
-      path: "request/1/edit",
-      description: "リクエスト編集",
-      status: "-",
-    },
-    {
-      path: "request/create",
-      description: "リクエスト作成",
-      status: "-",
-    },
 
-    { path: "message/", description: "メッセージ一覧", status: "-" },
+    { path: "message/", description: "メッセージルーム一覧", status: "-" },
     {
       path: "message/room/1",
       description: "メッセージルーム画面",
@@ -59,9 +29,40 @@ const pages = () => {
     },
 
     {
+      path: "category/1",
+      description: "カテゴリーから探す（静的一覧）",
+      status: "保留（済）",
+    },
+    {
+      path: "keep/",
+      description: "気になる商品・ユーザーのストック",
+      status: "保留（済）",
+    },
+    {
+      path: "viewed/1",
+      description: "閲覧した商品・ユーザーのページ",
+      status: "保留（済）",
+    },
+    {
+      path: "request/1",
+      description: "リクエスト詳細",
+      status: "保留",
+    },
+    {
+      path: "request/1/edit",
+      description: "リクエスト編集",
+      status: "保留",
+    },
+    {
+      path: "request/create",
+      description: "リクエスト作成",
+      status: "保留",
+    },
+
+    {
       path: "mypage/",
       description: "ログイン後マイページ",
-      status: "・・・一旦保留",
+      status: "保留",
     },
   ];
   return (

--- a/src/pages/user/[user_id]/index.tsx
+++ b/src/pages/user/[user_id]/index.tsx
@@ -8,6 +8,8 @@ import Image from "next/image";
 import { dummyUser } from "@/dummyData/user";
 import { DropDownBasic } from "@/component/molecules/dropdown/basic";
 import Link from "next/link";
+import { dummyItems } from "@/dummyData/items";
+import { BasicItemCard } from "@/component/molecules/card/basicItemCard";
 
 const UserIdIndex = () => {
   const router = useRouter();
@@ -101,6 +103,24 @@ const UserIdIndex = () => {
               <BasicTag className="mr-2" text="タグ名" removable />
               <BasicTag className="mr-2" text="タグ名" removable />
               <BasicTag className="mr-2" text="タグ名" removable />
+            </div>
+          </div>
+          <div className="rounded-lg bg-white p-8 mt-4">
+            <h2 className="font-bold text-lg text-gray-600 mb-4">
+              作成したサービス
+            </h2>
+            <div className="grid grid-cols-4 gap-4">
+              {dummyItems.map((i) => (
+                <BasicItemCard key={i.id} item={i} />
+              ))}
+            </div>
+            <div className="mt-4 text-center">
+              <button
+                type="button"
+                className="rounded-lg border border-primary-500 bg-primary-500 px-24 py-3 text-center text-base font-medium text-white shadow-sm transition-all hover:border-primary-700 hover:bg-primary-700 focus:ring focus:ring-primary-200 disabled:cursor-not-allowed disabled:border-primary-300 disabled:bg-primary-300"
+              >
+                もっと見る
+              </button>
             </div>
           </div>
         </main>


### PR DESCRIPTION
# やったこと
## テンプレート更新
- ログイン済ヘッダーに、出品するボタン
- ユーザー詳細に自身が作成したアイテムを表示

## 作成済pagesの更新
- 保留にしたいページに印を付ける